### PR TITLE
Fix FT_Face free

### DIFF
--- a/ext/cairo/rb_cairo_font_face.c
+++ b/ext/cairo/rb_cairo_font_face.c
@@ -39,6 +39,10 @@ static ID cr_id_at_need_clusters;
 static ID cr_id_at_need_cluster_flags;
 #endif
 
+#if CAIRO_HAS_FT_FONT
+static FT_Library library;
+#endif
+
 #define _SELF  (RVAL2CRFONTFACE(self))
 
 static inline void
@@ -143,28 +147,39 @@ handle_ft_error(FT_Error error)
   rb_raise(rb_eCairo_FreeType2Error, "FreeType2 Error: Unknown error %d.", error);
 }
 
+static void
+ft_face_free(void *ptr) {
+  FT_Face face = *((FT_Face *) ptr);
+  FT_Error err;
+
+  if ((err = FT_Done_Face(face)) != FT_Err_Ok)
+    handle_ft_error(err);
+}
+
 static VALUE
 cr_font_face_create_for_ft_face (VALUE self, VALUE path)
 {
-  FT_Library library;
+  FT_Library lib;
   FT_Face face;
   FT_Error error;
   cairo_font_face_t *cairo_face;
+  cairo_status_t status;
 
-  error = FT_Init_FreeType( &library );
-  if ( error )
-    handle_ft_error( error );
+  lib = library;
+  error = FT_New_Face(lib, RSTRING_PTR(path), 0, &face);
+  if (error != FT_Err_Ok)
+    handle_ft_error(error);
 
-  error = FT_New_Face( library, RSTRING_PTR(path), 0, &face );
-  if ( error != FT_Err_Ok )
-    handle_ft_error( error );
+  cairo_face = cairo_ft_font_face_create_for_ft_face (face, 0);
+  status = cairo_font_face_set_user_data (cairo_face, &ruby_object_key, (void *) self, (cairo_destroy_func_t) ft_face_free);
 
-  cairo_face = cairo_ft_font_face_create_for_ft_face ( face, 0 );
+  if (status != CAIRO_STATUS_SUCCESS) {
+    cairo_font_face_destroy(cairo_face);
+    FT_Done_Face(face);
+    return Qnil;
+  }
 
-  FT_Done_Face ( face );
-  FT_Done_FreeType ( library );
-
-  return rb_cairo_font_face_to_ruby_object ( cairo_face );
+  return rb_cairo_font_face_to_ruby_object (cairo_face);
 }
 #endif
 
@@ -714,6 +729,10 @@ Init_cairo_font (void)
 #if CAIRO_HAS_FT_FONT
   rb_define_singleton_method (rb_cCairo_FontFace, "create_for_ft_face",
                               cr_font_face_create_for_ft_face, 1);
+
+  FT_Error error = FT_Init_FreeType(&library);
+  if (error)
+    handle_ft_error(error);
 #endif
 
 #if CAIRO_CHECK_VERSION(1, 7, 6)


### PR DESCRIPTION
- Sets the `FT_Library` as static
- Initializes the `FT_Library` in `cr_font_face_allocate`
- Destroys the `FT_Library` in `cr_font_face_free`
- Uses Cairo font user data to attach a destroy function to free the `FT_Face` when the Cairo face is freed
